### PR TITLE
test_pytomvolume_vs_numpy e2etest consistency update

### DIFF
--- a/tests/E2ETests/test_pytomvolume_vs_numpy.py
+++ b/tests/E2ETests/test_pytomvolume_vs_numpy.py
@@ -124,7 +124,7 @@ class NumericalTest(unittest.TestCase):
         print('fft rmsd imag: ', self.rmsd(ft_pytomvol.imag, ft_npcp.imag))
         # self.display_diff_fft(np.abs(ft_pytomvol.real - ft_npcp.real), np.abs(ft_pytomvol.imag - ft_npcp.imag))
         self.assertAlmostEqual(ccc, 1.0, places=4,
-                               msg='correlation not sufficient between pytom.lin.pytom_volume fft and numpy/cupy fft')
+                               msg='correlation not sufficient between pytom.lib.pytom_volume fft and numpy/cupy fft')
 
     def rotation(self):
         rt_pytomvol = self.rotatePyTomVol()


### PR DESCRIPTION
updated test that checks correspondence between pytom_volume and numpy objects

- seeded the random number generator so that the test produces consistent output
- updated the rotation angles so that they are in degrees instead of radians
  - cross-correlation coef decreased after this update to 0.7 because two volumes of random noise are rotated. This reveals tiny differences in interoplation. Before, the angles were very small (due to missing rad2deg conversion) so the rotated volumes were more consistent.
- set the volume dimensions to even numbers because I know the wedge is slightly different for uneven z-height (but this is already covered in the unittest: test_WedgeTest.py)